### PR TITLE
Fix/stackname validation

### DIFF
--- a/.changeset/cyan-impalas-protect.md
+++ b/.changeset/cyan-impalas-protect.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/backend-cli': patch
+---
+
+stackname validation now allows customers to point to nested stack

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, it, mock } from 'node:test';
 import { GenerateOutputsCommand } from './generate_outputs_command.js';
 import { ClientConfigFormat } from '@aws-amplify/client-config';
 import yargs, { CommandModule } from 'yargs';
-import { TestCommandRunner } from '../../../test-utils/command_runner.js';
+import {
+  TestCommandError,
+  TestCommandRunner,
+} from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { AppBackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
@@ -11,7 +14,6 @@ import { SandboxBackendIdResolver } from '../../sandbox/sandbox_id_resolver.js';
 import { S3Client } from '@aws-sdk/client-s3';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
-import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 void describe('generate outputs command', () => {
   const clientConfigGeneratorAdapter = new ClientConfigGeneratorAdapter({
@@ -96,9 +98,9 @@ void describe('generate outputs command', () => {
   void it('throws an error for invalid stack name', async () => {
     await assert.rejects(
       commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
-      (error: AmplifyUserError) => {
-        assert.strictEqual(error.name, 'InvalidStackNameError');
-        assert.strictEqual(error.message, 'Invalid stack name: 1invalid');
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'InvalidStackNameError');
+        assert.strictEqual(error.error.message, 'Invalid stack name: 1invalid');
         return true;
       }
     );

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -2,10 +2,7 @@ import { beforeEach, describe, it, mock } from 'node:test';
 import { GenerateOutputsCommand } from './generate_outputs_command.js';
 import { ClientConfigFormat } from '@aws-amplify/client-config';
 import yargs, { CommandModule } from 'yargs';
-import {
-  TestCommandError,
-  TestCommandRunner,
-} from '../../../test-utils/command_runner.js';
+import { TestCommandRunner } from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { AppBackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
@@ -14,6 +11,7 @@ import { SandboxBackendIdResolver } from '../../sandbox/sandbox_id_resolver.js';
 import { S3Client } from '@aws-sdk/client-s3';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { AmplifyUserError } from '@aws-amplify/platform-core';
 
 void describe('generate outputs command', () => {
   const clientConfigGeneratorAdapter = new ClientConfigGeneratorAdapter({
@@ -99,9 +97,9 @@ void describe('generate outputs command', () => {
     await assert.rejects(
       () =>
         commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
-      (error: TestCommandError) => {
-        assert.strictEqual(error.error.name, 'InvalidStackNameError');
-        assert.strictEqual(error.error.message, 'Invalid stack name: 1invalid');
+      (error: AmplifyUserError) => {
+        assert.strictEqual(error.name, 'InvalidStackNameError');
+        assert.strictEqual(error.message, 'Invalid stack name: 1invalid');
         return true;
       }
     );

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -97,6 +97,7 @@ void describe('generate outputs command', () => {
       commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
       {
         name: 'InvalidStackNameError',
+        message: 'Invalid stack name: 1invalid',
       }
     );
   });

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -97,7 +97,7 @@ void describe('generate outputs command', () => {
       commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
       {
         name: 'AmplifyUserError',
-        code: 'InvalidStackName',
+        code: 'InvalidStackNameError',
       }
     );
   });

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, it, mock } from 'node:test';
 import { GenerateOutputsCommand } from './generate_outputs_command.js';
 import { ClientConfigFormat } from '@aws-amplify/client-config';
 import yargs, { CommandModule } from 'yargs';
-import { TestCommandRunner } from '../../../test-utils/command_runner.js';
+import {
+  TestCommandError,
+  TestCommandRunner,
+} from '../../../test-utils/command_runner.js';
 import assert from 'node:assert';
 import { AppBackendIdentifierResolver } from '../../../backend-identifier/backend_identifier_resolver.js';
 import { ClientConfigGeneratorAdapter } from '../../../client-config/client_config_generator_adapter.js';
@@ -94,10 +97,12 @@ void describe('generate outputs command', () => {
 
   void it('throws an error for invalid stack name', async () => {
     await assert.rejects(
-      commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
-      {
-        name: 'InvalidStackNameError',
-        message: 'Invalid stack name: 1invalid',
+      () =>
+        commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
+      (error: TestCommandError) => {
+        assert.strictEqual(error.error.name, 'InvalidStackNameError');
+        assert.strictEqual(error.error.message, 'Invalid stack name: 1invalid');
+        return true;
       }
     );
   });

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -95,8 +95,7 @@ void describe('generate outputs command', () => {
 
   void it('throws an error for invalid stack name', async () => {
     await assert.rejects(
-      () =>
-        commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
+      commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
       (error: AmplifyUserError) => {
         assert.strictEqual(error.name, 'InvalidStackNameError');
         assert.strictEqual(error.message, 'Invalid stack name: 1invalid');

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -96,8 +96,7 @@ void describe('generate outputs command', () => {
     await assert.rejects(
       commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
       {
-        name: 'AmplifyUserError',
-        code: 'InvalidStackNameError',
+        name: 'InvalidStackNameError',
       }
     );
   });

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.test.ts
@@ -82,6 +82,36 @@ void describe('generate outputs command', () => {
     );
   });
 
+  void it('generates and writes config for stack with slashes', async () => {
+    await commandRunner.runCommand(
+      'outputs --stack parent/child --out-dir /foo/bar'
+    );
+    assert.equal(generateClientConfigMock.mock.callCount(), 1);
+    assert.deepEqual(generateClientConfigMock.mock.calls[0].arguments[0], {
+      stackName: 'parent/child',
+    });
+  });
+
+  void it('throws an error for invalid stack name', async () => {
+    await assert.rejects(
+      commandRunner.runCommand('outputs --stack 1invalid --out-dir /foo/bar'),
+      {
+        name: 'AmplifyUserError',
+        code: 'InvalidStackName',
+      }
+    );
+  });
+
+  void it('accepts valid stack name with hyphens', async () => {
+    await commandRunner.runCommand(
+      'outputs --stack valid-stack-name --out-dir /foo/bar'
+    );
+    assert.equal(generateClientConfigMock.mock.callCount(), 1);
+    assert.deepEqual(generateClientConfigMock.mock.calls[0].arguments[0], {
+      stackName: 'valid-stack-name',
+    });
+  });
+
   void it('generates and writes config for branch', async () => {
     await commandRunner.runCommand(
       'outputs --branch branch_name --out-dir /foo/bar'

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -87,6 +87,16 @@ export class GenerateOutputsCommand
         type: 'string',
         array: false,
         group: 'Stack identifier',
+        coerce: (arg: string) => {
+          if (!/^[a-zA-Z][-a-zA-Z0-9/]*$/.test(arg)) {
+            throw new AmplifyUserError('InvalidStackNameError', {
+              message: `Invalid stack name: ${arg}`,
+              resolution:
+                'Stack name must start with a letter and can only contain alphanumeric characters, hyphens, and slashes.',
+            });
+          }
+          return arg;
+        },
       })
       .option('app-id', {
         conflicts: ['stack'],

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -88,11 +88,11 @@ export class GenerateOutputsCommand
         array: false,
         group: 'Stack identifier',
         coerce: (arg: string) => {
-          if (!/^[a-zA-Z][-_a-zA-Z0-9/]*$/.test(arg)) {
+          if (/^[a-zA-Z][-_a-zA-Z0-9/]*$/.test(arg)) {
             throw new AmplifyUserError('InvalidStackNameError', {
               message: `Invalid stack name: ${arg}`,
               resolution:
-                'Stack name must start with a letter and can only contain alphanumeric characters, hyphens, and slashes.',
+                'Stack name must start with a letter and can only contain alphanumeric characters, hyphens, underscores and slashes.',
             });
           }
           return arg;

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -88,18 +88,6 @@ export class GenerateOutputsCommand
         array: false,
         group: 'Stack identifier',
       })
-      .check((argv) => {
-        if (argv.stack) {
-          if (!/^[a-zA-Z][-_a-zA-Z0-9/]*$/.test(argv.stack)) {
-            throw new AmplifyUserError('InvalidStackNameError', {
-              message: `Invalid stack name: ${argv.stack}`,
-              resolution:
-                'Stack name must start with a letter and can only contain alphanumeric characters, hyphens, underscores and slashes.',
-            });
-          }
-        }
-        return true;
-      })
       .option('app-id', {
         conflicts: ['stack'],
         describe: 'The Amplify App ID of the project',
@@ -134,6 +122,19 @@ export class GenerateOutputsCommand
         array: false,
         choices: Object.values(ClientConfigVersionOption),
         default: DEFAULT_CLIENT_CONFIG_VERSION,
+      })
+      .check((argv) => {
+        if (argv.stack) {
+          const identifierRegex = /^[a-zA-Z][-_a-zA-Z0-9/]*$/;
+          if (!argv.stack.match(identifierRegex)) {
+            throw new AmplifyUserError('InvalidStackNameError', {
+              message: `Invalid stack name: ${argv.stack}`,
+              resolution:
+                'Stack name must start with a letter and can only contain alphanumeric characters, hyphens, underscores and slashes.',
+            });
+          }
+        }
+        return true;
       });
   };
 }

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -88,7 +88,7 @@ export class GenerateOutputsCommand
         array: false,
         group: 'Stack identifier',
         coerce: (arg: string) => {
-          if (!/^[a-zA-Z][-a-zA-Z0-9/]*$/.test(arg)) {
+          if (!/^[a-zA-Z][-_a-zA-Z0-9/]*$/.test(arg)) {
             throw new AmplifyUserError('InvalidStackNameError', {
               message: `Invalid stack name: ${arg}`,
               resolution:

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -55,6 +55,17 @@ export class GenerateOutputsCommand
   handler = async (
     args: ArgumentsCamelCase<GenerateOutputsCommandOptions>
   ): Promise<void> => {
+    if (args.stack) {
+      const identifierRegex = /^[a-zA-Z][-_a-zA-Z0-9/]*$/;
+      if (!args.stack.match(identifierRegex)) {
+        throw new AmplifyUserError('InvalidStackNameError', {
+          message: `Invalid stack name: ${args.stack}`,
+          resolution:
+            'Stack name must start with a letter and can only contain alphanumeric characters, hyphens, underscores and slashes.',
+        });
+      }
+    }
+
     const backendIdentifier =
       await this.backendIdentifierResolver.resolveDeployedBackendIdentifier(
         args
@@ -122,19 +133,6 @@ export class GenerateOutputsCommand
         array: false,
         choices: Object.values(ClientConfigVersionOption),
         default: DEFAULT_CLIENT_CONFIG_VERSION,
-      })
-      .check((argv) => {
-        if (argv.stack) {
-          const identifierRegex = /^[a-zA-Z][-_a-zA-Z0-9/]*$/;
-          if (!argv.stack.match(identifierRegex)) {
-            throw new AmplifyUserError('InvalidStackNameError', {
-              message: `Invalid stack name: ${argv.stack}`,
-              resolution:
-                'Stack name must start with a letter and can only contain alphanumeric characters, hyphens, underscores and slashes.',
-            });
-          }
-        }
-        return true;
       });
   };
 }

--- a/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
+++ b/packages/cli/src/commands/generate/outputs/generate_outputs_command.ts
@@ -87,16 +87,18 @@ export class GenerateOutputsCommand
         type: 'string',
         array: false,
         group: 'Stack identifier',
-        coerce: (arg: string) => {
-          if (/^[a-zA-Z][-_a-zA-Z0-9/]*$/.test(arg)) {
+      })
+      .check((argv) => {
+        if (argv.stack) {
+          if (!/^[a-zA-Z][-_a-zA-Z0-9/]*$/.test(argv.stack)) {
             throw new AmplifyUserError('InvalidStackNameError', {
-              message: `Invalid stack name: ${arg}`,
+              message: `Invalid stack name: ${argv.stack}`,
               resolution:
                 'Stack name must start with a letter and can only contain alphanumeric characters, hyphens, underscores and slashes.',
             });
           }
-          return arg;
-        },
+        }
+        return true;
       })
       .option('app-id', {
         conflicts: ['stack'],


### PR DESCRIPTION

I've identified that we need to modify the 'stack' option in the 'builder' method to allow slashes in stack names. I will update the validation logic for the 'stack' option to permit slashes.